### PR TITLE
Bugfix/no issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,28 +47,47 @@ cp templates/featured_example.html templates/featured.html
 
 ## Configuration
 
-Take a look at `config.py`.  There are two settings which are pretty self-explanatory:
+There are three possible options for the behavior of this plugin:
+
+- random selection from all pages (changes each day)
+- "on this day" selection, defaults to random if nothing occurred on that day
+- user selected pages of interest
+
+Please find below descriptions of how to configure the plugin for each of the above options.
+
+### Random Selection
+
+`config.py`
 
 ```
-# Set to True to use random pages instead of curated selections in PAGES
 RANDOM = True
+NUMBER = 4      # number of results that will be returned
+```
 
-# Set to True to enable the 'This day in history' function, given that RANDOM is False
+### On This Day
+
+You must first set RANDOM to False to use this feature
+
+`config.py`
+
+```
+RANDOM = False
 THISDAY = True
+MINYEAR = 1750   # earliest year to search for "on this day"
+MAXYEAR = 2000   # latest year to search for "on this day"
+NUMBER = 4       # number of results that will be returned
+```
 
-# Set to earliest year to search with THISDAY
-MINYEAR = 1900
+### User Selection
 
-# Set to latest year to search  with THISDAY
-MAXYEAR = 1922
+To get at the user selected featured pages, first set RANDOM and THISDAY to False, then add information for your specifically requested pages.
 
-# The number of results that will be displayed
+`config.py`
+
+```
+RANDOM = False
+THISDAY = False
 NUMBER = 4
-```
-
-Setting RANDOM and THISDAY both to False will mean that you can use the following setting in the config file:
-
-```
 PAGES = (
   {
       'lccn': 'sn83045350',
@@ -82,22 +101,23 @@ PAGES = (
       'date': '1878-01-03',
       'edition': 1,
       'sequence': 2,
-      'caption': 'This is the second one'
+      'caption': 'This is the second page of an issue'
   },
 )
 ```
 
-You must hand enter the pages that you would like to appear as featured.  If you enter more pages than your max NUMBER, then a subset will be selected randomly (each day) from your featured set.  You can get the information for lccn, date, edition, and sequence from the URL for an individual page.
+If you enter more `PAGES` than your max `NUMBER`, a subset will be selected randomly (each day) from your featured set.  You can get the information for lccn, date, edition, and sequence from the URL for an individual page.
 
 `http://newspapers.uni.edu/lccn/sn83045350/1878-01-03/ed-1/seq-1/`
 
-`edition` will typically always be 1, unless if the paper has morning and evening runs, etc
-`sequence` refers to the page number, so 1 is also a good choice if you want the front page of a particular day
+- `edition` will typically always be 1, unless if the paper has morning and evening runs, etc
+- `sequence` refers to the page number, so 1 is also a good choice if you want the front page of a particular day
 
 
-You may also want to change the text on the featured content page.  Open up `templates/featured.html` and add any HTML you need in `{% block featured_description %}`
+## Customizing the Template
 
-You will likely need to restart your app before you see the changes!
+You may want to change the text on the featured content page.  Open up `templates/featured.html` and add any HTML you need in `{% block featured_description %}`
+
 
 ## API use
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The setup for this plugin is slightly involved, but bear with us!
 git clone git@github.com:open-oni/plugin_featured_content.git onisite/plugins/featured_content
 ```
 
-Add it to your `INSTALLED_APPS` in `onisite/settings_local.py`:
+Add it to your `INSTALLED_APPS` in `onisite/settings_local.py`, above your theme (`default` or custom themes you've created):
 
 ```
 INSTALLED_APPS = (
@@ -53,10 +53,20 @@ Take a look at `config.py`.  There are two settings which are pretty self-explan
 # Set to True to use random pages instead of curated selections in PAGES
 RANDOM = True
 
+# Set to True to enable the 'This day in history' function, given that RANDOM is False
+THISDAY = True
+
+# Set to earliest year to search with THISDAY
+MINYEAR = 1900
+
+# Set to latest year to search  with THISDAY
+MAXYEAR = 1922
+
 # The number of results that will be displayed
 NUMBER = 4
 ```
-Setting RANDOM to False will mean that you can use the following setting in the config file:
+
+Setting RANDOM and THISDAY both to False will mean that you can use the following setting in the config file:
 
 ```
 PAGES = (
@@ -77,7 +87,7 @@ PAGES = (
 )
 ```
 
-Unfortunately, at this time, you need to hand enter the pages that you would like to appear as featured.  If you enter more pages than your max NUMBER, then only that many will be selected at random from your featured set.  You can get the information like lccn, date, edition, and sequence from the URL for an individual page.
+You must hand enter the pages that you would like to appear as featured.  If you enter more pages than your max NUMBER, then a subset will be selected randomly (each day) from your featured set.  You can get the information for lccn, date, edition, and sequence from the URL for an individual page.
 
 `http://newspapers.uni.edu/lccn/sn83045350/1878-01-03/ed-1/seq-1/`
 

--- a/helpers.py
+++ b/helpers.py
@@ -85,12 +85,16 @@ def _pages_this_day():
 def _random_pages(limit):
     page_len = models.Page.objects.count()
     if page_len:
-        indices = ([i for i in xrange(page_len)]
-                    if page_len < limit
-                    else random.sample(xrange(page_len), limit))
+        indices = []
         pages = []
+        if page_len < limit:
+            indices = [i for i in xrange(page_len)]
+        else:
+            indices = random.sample(xrange(page_len), limit)
+
+        page_objects = models.Page.objects.all()
         for index in indices:
-            pages.append(models.Page.objects.all()[index])
+            pages.append(page_objects[index])
 
         return map(_get_page_by_object, pages)
     else:

--- a/helpers.py
+++ b/helpers.py
@@ -11,13 +11,8 @@ def get_pages():
     # an entire day
     random.seed(datetime.date.today().strftime("%Y%m%d"))
 
-    # Get and randomize pages
-    pages = []
-    all_pages, this_day_title = _get_pages()
-    if len(all_pages) > 0:
-        rand_nums = random.sample(xrange(len(all_pages)), config.NUMBER)
-        for num in rand_nums:
-            pages.append(all_pages[num])
+    # Get pages and randomize where necessary
+    pages, this_day_title = _get_pages()
 
     # Clear the seed so anything else using random numbers isn't affected
     random.seed(None)
@@ -43,7 +38,20 @@ def _get_pages():
     if isrand:
         return _random_pages(config.NUMBER), False
 
-    return map(_get_page_by_info, config.PAGES), False
+    return _featured_pages(config.PAGES, config.NUMBER), False
+
+def _featured_pages(pages, limit):
+    feat_pages = map(_get_page_by_info, pages)
+    # remove requested pages which were not found in the database
+    feat_pages = filter(None, feat_pages)
+    if len(feat_pages) <= limit:
+        return feat_pages
+    else:
+        pages = []
+        rand_nums = random.sample(xrange(len(feat_pages)), limit)
+        for num in rand_nums:
+            pages.append(all_pages[num])
+        return pages
 
 def _pages_this_day():
     """Find any pages within the min/max years and today's month/year"""
@@ -55,12 +63,12 @@ def _pages_this_day():
     now = datetime.date.today()
 
     # Grab each issue that matches, and create a page_info structure for the
-    # first page of that issue.  For sanity's sake, we only pull 100 max.
+    # first page of that issue.  Grabbing only the set number requested by user
     issues = models.Issue.objects
     issues = issues.filter(date_issued__range=(dt_range_start, dt_range_end))
     issues = issues.filter(date_issued__month = now.month)
     issues = issues.filter(date_issued__day = now.day)
-    for issue in issues[:100]:
+    for issue in issues[:config.NUMBER]:
         first_page = issue.first_page
         if first_page and first_page.jp2_filename:
             pages.append({
@@ -76,12 +84,17 @@ def _pages_this_day():
 
 def _random_pages(limit):
     page_len = models.Page.objects.count()
-    indices = random.sample(xrange(page_len), limit)
-    pages = []
-    for index in indices:
-        pages.append(models.Page.objects.all()[index])
+    if page_len:
+        indices = ([i for i in xrange(page_len)]
+                    if page_len < limit
+                    else random.sample(xrange(page_len), limit))
+        pages = []
+        for index in indices:
+            pages.append(models.Page.objects.all()[index])
 
-    return map(_get_page_by_object, pages)
+        return map(_get_page_by_object, pages)
+    else:
+        return []
 
 def _get_page_by_object(page_obj):
     issue_obj = page_obj.issue
@@ -102,7 +115,9 @@ def _get_page_by_info(page_info):
         page_info['page_obj'] = (title
                              .issues.get(edition=page_info['edition'], date_issued=page_info['date'])
                              .pages.get(sequence=page_info['sequence']))
+        # if there is no record in the database for a particular page, then set to None
+        if page_info['page_obj'] is None:
+            page_info = None
     except:
-        page_info['name'] = 'Unknown Title'
-        page_info['page_obj'] = None
+        page_info = None
     return page_info

--- a/templates/_featured_base.html
+++ b/templates/_featured_base.html
@@ -22,18 +22,32 @@
     </div>
     <div class="col-md-8">
       {% block featured_pages %}
-        <h3>Featured Content</h3>
+        {% if this_day_title %}
+          <h3>On This Day</h3>
+        {% else %}
+          <h3>Featured Content</h3>
+        {% endif %}
         <ul class="featured_content">
-          {% for page in pages %}
-            <li>
-              <a href="{% url 'openoni_page' page.lccn page.date page.edition page.sequence %}">
-                <img src="{% thumb_image_url page.page_obj %}" alt="" />
-                <p class="featured_title">{{ page.name }}</p>
-                <p class="featured_date">{{ page.date }}</p>
-                <p class="featured_caption">{{ page.caption }}</p>
-              </a>
-            </li>
-          {% endfor %}
+          {% if pages %}
+            {% for page in pages %}
+              {% if page.page_obj %}
+                <li>
+                  <a href="{% url 'openoni_page' page.lccn page.date page.edition page.sequence %}">
+                    {% if page.page_obj.relative_image_path %}
+                      <img src="{% thumb_image_url page.page_obj %}" alt="" />
+                    {% endif %}
+                    <p class="featured_title">{{ page.name }}</p>
+                    <p class="featured_date">{{ page.date }}</p>
+                    <p class="featured_caption">{{ page.caption }}</p>
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            {% block featured_no_content %}
+              <p>No content available</p>
+            {% endblock featured_no_content %}
+          {% endif %}
         </ul>
       {% endblock featured_pages %}
     </div>


### PR DESCRIPTION
error when page not in database requested in config file
  filter out pages which weren't found so not displayed at all
  instead of "Unknown Title"
  and then add a conditional in template just to make extra sure
  that the image error won't occur and no bad links displayed

also noticed that if you had 2 pages to display but your limit was 4
  error would be thrown because of how random selection being chosen
  (same error as when the database was not yet populated, therefore 0 pages)
  moved logic for number of pages returned and made sure that
  smaller numbers than limit would display the pages regardless
  changed the "on this day" feature to always use the "limit" num
  returned instead of returning 100 and then choosing randomly from that set

adds to documentation

closes https://github.com/open-oni/plugin_featured_content/issues/2