### PR TITLE
Better sample of pages shown from "this day" pages

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -69,7 +69,9 @@ def _pages_this_day():
     pages = pages.filter(issue__date_issued__day = now.day)
     pages = pages.filter(jp2_filename__isnull = False)
     pages = pages.filter(sequence = 1)
-    for page in pages[:config.NUMBER]:
+    rand_nums = random.sample(range(len(pages)), config.NUMBER)
+    for rand_num in rand_nums:
+        page = pages[rand_num]
         this_day_pages.append({
             'date': page.issue.date_issued,
             'edition': page.issue.edition,


### PR DESCRIPTION
- Was previously always showing the first matches for the query
  - This results in showing many matches from the same title
- New code randomizes seeded by today's date so the same four are shown
  throughout the day, but pages are from throughout the set of pages
  matching the "this day" query